### PR TITLE
Fix undefined Settings error.

### DIFF
--- a/templates/admin/plugins/sso-facebook.tpl
+++ b/templates/admin/plugins/sso-facebook.tpl
@@ -17,7 +17,7 @@
 <button class="btn btn-lg btn-primary" id="save">Save</button>
 
 <script>
-	require(['forum/admin/settings'], function(Settings) {
+	require(['admin/settings'], function(Settings) {
 		Settings.prepare();
 	});
 </script>


### PR DESCRIPTION
With the latest master of nodebb, I was getting an undefined Settings javascript error in the admin settings page for the plugin.  This fixes that javascript error.
