### PR TITLE
without `displayName` in profile fields, error emits + auth fails

### DIFF
--- a/library.js
+++ b/library.js
@@ -58,7 +58,7 @@
 				clientSecret: Facebook.settings.secret,
 				callbackURL: nconf.get('url') + '/auth/facebook/callback',
 				passReqToCallback: true,
-                                profileFields: ['id', 'emails', 'name']
+                                profileFields: ['id', 'emails', 'name', 'displayName']
 			}, function(req, accessToken, refreshToken, profile, done) {
 				if (req.hasOwnProperty('user') && req.user.hasOwnProperty('uid') && req.user.uid > 0) {
 					// Save facebook-specific information to the user


### PR DESCRIPTION
Phew, took me one hour to finally nail the issue. The frontend shows a oauth error, 

```
/auth/facebook/callback
This authorization code has been used.
```
And i spend the whole hour trying to nail the oauth error, but actually it throws two error in log.

```js
23/11 10:37 [28114] - error: TypeError: Cannot call method 'trim' of undefined
    at Object.User.create (/var/www/pcwrforum/nodebb/src/user/create.js:17:33)
    at /var/www/pcwrforum/nodebb/node_modules/nodebb-plugin-sso-facebook/library.js:161:12
    at try_callback (/var/www/pcwrforum/nodebb/node_modules/redis/index.js:573:9)
................
................
[cluster] Child Process (28114) has exited (code: 1, signal: null)
```

Another one 

```js
23/11 10:37 [28116] - error: /auth/facebook/callback
 FacebookTokenError: This authorization code has been used.
...............
```

without `displayName` in requested profile fields in facebook request, name remains undefined, thus the error related to `trim`. For some reason this causes the request to re-execute and thus the causing the "code already used" error from facebook auth.

adding `displayName` to profileFields solves both errors. oAuth works properly and new user is created.