### PR TITLE
Update nbbpm compatibility to support 0.9.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,6 @@
     "passport-facebook": "~1.0.2"
   },
   "nbbpm": {
-    "compatibility": "^0.8.3"
+    "compatibility": "^0.8.3 || ^0.9.0"
   }
 }


### PR DESCRIPTION
To get rid of the warnings in the logs