### PR TITLE
Update to new Facebook policy

### DIFF
--- a/library.js
+++ b/library.js
@@ -131,7 +131,7 @@
 				url: '/auth/facebook',
 				callbackURL: '/auth/facebook/callback',
 				icon: constants.admin.icon,
-				scope: 'email, user_friends'
+				scope: 'public_profile, email'
 			});
 		}
 


### PR DESCRIPTION
Since recently, Facebook Login gives only public profile and email by default. Any other data such as user friends will need an app review by Facebook. This pull request updates a line of library.js to the new default.

Currently, when using this NodeBB plugin to create a new app with Facebook Login, it doesn't work, and trying to register it says:

> Submit for Login Review
> Some of the permissions below have not been approved for use by Facebook.
> 
> (...) will receive: your public profile, friend list and email address.

And, on Facebook for Developers:

> We are not reviewing apps at this time due to changes we are making to the Facebook Platform.

With the small change of this pull request, it works for public profile and email. Of course, the user friends list is not needed at all for login.

Related info:

- [Facebook will limit developers’ access to account data - The Verge](https://www.theverge.com/2018/3/21/17148726/facebook-developer-data-crackdown-cambridge-analytica)
- [Overview - Facebook Login](https://developers.facebook.com/docs/facebook-login/overview)
- [Reference - Facebook Login](https://developers.facebook.com/docs/facebook-login/permissions)
